### PR TITLE
Fix malloc size parameter

### DIFF
--- a/start.bash
+++ b/start.bash
@@ -2,5 +2,5 @@
 set -e
 
 exec bash -c \
-  "exec varnishd -F -f $VCL_CONFIG -s malloc,$CACHE_SIZE \
+  "exec varnishd -F -f $VCL_CONFIG -s malloc,$VARNISH_MALLOC_SIZE \
   $VARNISHD_PARAMS"


### PR DESCRIPTION
There doesn't seem to be a `CACHE_SIZE` variable, but there is `VARNISH_MALLOC_SIZE`, thus I assume this should be used to set the malloc size of varnish.